### PR TITLE
bump helm to 3.8.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN cd /usr/local/bin \
     && curl -k -sS -o kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.16.15/2020-11-02/bin/linux/amd64/kubectl \
     && chmod 755 /usr/local/bin/kubectl
 
-RUN curl -L https://get.helm.sh/helm-v3.4.2-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /usr/local/bin/helm && rm -rf linux-amd64
+RUN curl -L https://get.helm.sh/helm-v3.8.2-linux-amd64.tar.gz | tar xz && mv linux-amd64/helm /usr/local/bin/helm && rm -rf linux-amd64
 
 RUN cd /usr/local/bin \
     && curl -k -sS -o aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.18.9/2020-11-02/bin/linux/amd64/aws-iam-authenticator \


### PR DESCRIPTION
Bumping helm version to 3.8.2 as a potential fix to a Prometheus issue that seems to be fixed with Helm versions > 3.7. 